### PR TITLE
feat: add required

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
-export * from './unpartial'
-export * from './unpartialRecursively'
+export * from './required';
+export * from './unpartial';
+export * from './unpartialRecursively';

--- a/src/required.spec.ts
+++ b/src/required.spec.ts
@@ -1,0 +1,101 @@
+import { required } from './required';
+test('none of the inputs are modified', () => {
+  const source1 = { a: 1 }
+  const source2 = { b: 2 }
+  const source3 = { c: 3 }
+  required(source1, source2, source3)
+
+  expect(source1).toEqual({ a: 1 })
+  expect(source2).toEqual({ b: 2 })
+  expect(source3).toEqual({ c: 3 })
+})
+
+test('source2 can be undefined', () => {
+  const actual = required({ a: 1 }, undefined)
+
+  expect(actual).toEqual({ a: 1 })
+})
+
+test('source2 can be null', () => {
+  const actual = required({ a: 1 }, null)
+
+  expect(actual).toEqual({ a: 1 })
+})
+
+test('source3 can be undefined', () => {
+  const actual = required({ a: 1 }, undefined, undefined)
+
+  expect(actual).toEqual({ a: 1 })
+})
+
+test('source3 can be null', () => {
+  const actual = required({ a: 1 }, null, null)
+
+  expect(actual).toEqual({ a: 1 })
+})
+
+type Source1 = {
+  a: string,
+  b: number,
+  c: { d: boolean }
+  e?: string
+}
+
+test('can access types in source1', () => {
+  const source1: Partial<Source1> = { a: 'a', b: 2, c: { d: true } }
+
+  const actual = required(source1, undefined)
+
+  expect(actual.a).toEqual('a')
+  expect(actual.b).toEqual(2)
+  expect(actual.c.d).toEqual(true)
+  actual.e = undefined
+})
+
+type Source2 = {
+  p: string,
+  q: number,
+  r: { s: boolean }
+  t?: string
+}
+
+test('can access types in source2', () => {
+  const source1: Partial<Source1> = { a: 'a', b: 2, c: { d: true } }
+  const source2: Partial<Source2> = { p: 'p', q: 2, r: { s: true } }
+
+  const actual = required(source1, source2)
+
+  expect(actual.p).toEqual('p')
+  expect(actual.q).toEqual(2)
+  expect(actual.r.s).toEqual(true)
+  actual.t = undefined
+})
+
+type Source3 = {
+  w: string,
+  x: number,
+  y: { z: boolean }
+  u?: string
+}
+
+test('can access types in source2', () => {
+  const source1: Partial<Source1> = { a: 'a', b: 2, c: { d: true } }
+  const source2: Partial<Source2> = { p: 'p', q: 2, r: { s: true } }
+  const source3: Partial<Source3> = { w: 'w', x: 2, y: { z: true } }
+
+  const actual = required(source1, source2, source3)
+
+  expect(actual.w).toEqual('w')
+  expect(actual.x).toEqual(2)
+  expect(actual.y.z).toEqual(true)
+  actual.u = undefined
+})
+
+test('can explicitly specify target type', () => {
+  const actual = required<Source1>({ a: 'a' }, { b: 2 }, { c: { d: true } })
+
+  expect(actual.a).toEqual('a')
+  expect(actual.b).toEqual(2)
+  expect(actual.c.d).toEqual(true)
+  actual.e = undefined
+})

--- a/src/required.ts
+++ b/src/required.ts
@@ -1,0 +1,10 @@
+export function required<
+  T extends object,
+  R extends object = {},
+  S extends object = {}
+>(source1: Partial<T>, source2: Partial<R> | undefined | null, source3?: Partial<S> | null): T & R & S {
+  let result = {}
+  const entries = [source1, source2, source3].filter(x => !!x)
+  entries.forEach(e => result = { ...result, ...e })
+  return result as any
+}

--- a/src/unparital.spec.ts
+++ b/src/unparital.spec.ts
@@ -1,11 +1,12 @@
 import t from 'assert';
 import { unpartial } from '.';
 
-interface Config {
+interface TestSubject {
   require: { a: number }
   optional?: { a: number }
 }
-const defaultConfig: Config = { require: { a: 1 } }
+
+const defaultConfig: TestSubject = { require: { a: 1 } }
 
 test('undefined partial will be ignored', () => {
   t.strictEqual(unpartial(undefined as any, undefined), undefined)
@@ -48,7 +49,7 @@ test('null superBase returns null (in JS)', () => {
 
 
 test('base and partial are not modified', () => {
-  const base = { require: { a: 1 }, optional: { a: 2 } } as Config
+  const base = { require: { a: 1 }, optional: { a: 2 } } as TestSubject
   const partial = { require: { a: 3 } }
   const actual = unpartial(base, partial)
 
@@ -59,7 +60,7 @@ test('base and partial are not modified', () => {
 
 test('superBase base and partial are not modified', () => {
   const superBase = { require: { a: 1 } }
-  const base = { require: { a: 2 }, optional: { a: 3 } } as Config
+  const base = { require: { a: 2 }, optional: { a: 3 } } as TestSubject
   const partial = { require: { a: 4 } }
   const actual = unpartial(superBase, base, partial)
 
@@ -79,7 +80,7 @@ test('unpartial a partial config with optional', () => {
 })
 
 test(`optional partial would not affact type`, () => {
-  const partial: Partial<Config> | undefined = undefined
+  const partial: Partial<TestSubject> | undefined = undefined
   const config = unpartial(defaultConfig, partial)
 
   // `require` is not optional
@@ -89,6 +90,6 @@ test(`optional partial would not affact type`, () => {
 })
 
 test('specify target interface explicitly', () => {
-  const x = unpartial<Config>({ require: { a: 1 } }, {})
+  const x = unpartial<TestSubject>({ require: { a: 1 } }, {})
   t.strictEqual(x.require.a, 1)
 })


### PR DESCRIPTION
This would be the new version of unpartial.

Adding it in as `required()` for field testing.