### PR TITLE
chore: upgrade to pnpm 11.1.3

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+minimumreleaseage=1440

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "type-plus": "^7.0.1",
     "typescript": "^5.0.0"
   },
-  "packageManager": "pnpm@10.7.1",
+  "packageManager": "pnpm@11.1.3",
   "engines": {
     "node": ">=6"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  '@swc/core': true
+  esbuild: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 allowBuilds:
   '@swc/core': true
   esbuild: true
+  fsevents: true


### PR DESCRIPTION
## Summary

- Upgrade pnpm to `11.1.3`
- Add `minimumreleaseage=1440` to `.npmrc` — blocks packages published in the last 24h, reducing supply chain attack risk
- Remove obsolete `use-lockfile-v6` setting (default since pnpm 9)
- Approve native build scripts via `pnpm-workspace.yaml`

## Test plan
- [ ] CI passes